### PR TITLE
Unify `AudioSink` and `AudioHandle`

### DIFF
--- a/examples/gain.rs
+++ b/examples/gain.rs
@@ -1,0 +1,67 @@
+use bevy::{
+    prelude::{App, Assets, Commands, Deref, Handle, Res, ResMut, StartupStage},
+    reflect::TypeUuid,
+    time::Time,
+    DefaultPlugins,
+};
+use bevy_oddio::{builtins::sine, output::AudioSink, Audio, AudioApp, AudioPlugin, ToSignal};
+use oddio::Sample;
+
+#[derive(TypeUuid)]
+#[uuid = "54498976-f7db-4ee7-a2e6-5fee0fcadbfb"]
+struct SineWithGain;
+
+impl ToSignal for SineWithGain {
+    type Settings = sine::Settings;
+    type Signal = oddio::Gain<oddio::Sine>;
+
+    fn to_signal(&self, settings: Self::Settings) -> Self::Signal {
+        oddio::Gain::new(oddio::Sine::new(settings.phase, settings.frequency_hz))
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(AudioPlugin)
+        .add_audio_source::<1, _, SineWithGain>()
+        .add_startup_system(init_assets)
+        .add_startup_system_to_stage(StartupStage::PostStartup, play_sine_with_gain)
+        .add_system(change_volume)
+        .run();
+}
+
+#[derive(Deref)]
+struct SineWithGainHandle(Handle<SineWithGain>);
+
+struct SineWithGainSink(Handle<AudioSink<SineWithGain>>);
+
+fn init_assets(mut commands: Commands, mut assets: ResMut<Assets<SineWithGain>>) {
+    let handle = assets.add(SineWithGain);
+    commands.insert_resource(SineWithGainHandle(handle));
+}
+
+fn play_sine_with_gain(
+    mut commands: Commands,
+    mut audio: ResMut<Audio<Sample, SineWithGain>>,
+    sine_with_gain: Res<SineWithGainHandle>,
+) {
+    let handle = audio.play(sine_with_gain.clone(), sine::Settings::new(0.0, 440.0));
+    commands.insert_resource(SineWithGainSink(handle));
+}
+
+fn change_volume(
+    sink_handle: Res<SineWithGainSink>,
+    mut sinks: ResMut<Assets<AudioSink<SineWithGain>>>,
+    time: Res<Time>,
+) {
+    let sink = match sinks.get_mut(&sink_handle.0) {
+        Some(sink) => sink,
+        None => return,
+    };
+
+    let factor = (time.seconds_since_startup().sin() + 1.0) / 2.0;
+
+    sink.control::<oddio::Gain<_>, _>()
+        .set_amplitude_ratio(factor as f32);
+}

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -3,11 +3,7 @@ use bevy::{
     reflect::TypeUuid,
     DefaultPlugins,
 };
-use bevy_oddio::{
-    frames::Stereo,
-    output::{AudioHandle, AudioSink},
-    Audio, AudioApp, AudioPlugin, ToSignal,
-};
+use bevy_oddio::{frames::Stereo, output::AudioSink, Audio, AudioApp, AudioPlugin, ToSignal};
 use oddio::Signal;
 
 #[derive(TypeUuid)]
@@ -49,7 +45,7 @@ fn main() {
 #[derive(Deref)]
 struct NoiseHandle(Handle<Noise>);
 
-struct NoiseSink(Handle<AudioHandle<Noise>>, Handle<AudioSink<Noise>>);
+struct NoiseSink(Handle<AudioSink<Noise>>);
 
 fn init_assets(mut commands: Commands, mut assets: ResMut<Assets<Noise>>) {
     let handle = assets.add(Noise);
@@ -61,6 +57,6 @@ fn play_noise(
     mut audio: ResMut<Audio<Stereo, Noise>>,
     noise: Res<NoiseHandle>,
 ) {
-    let handles = audio.play(noise.clone(), ());
-    commands.insert_resource(NoiseSink(handles.0, handles.1));
+    let handle = audio.play(noise.clone(), ());
+    commands.insert_resource(NoiseSink(handle));
 }

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -4,7 +4,7 @@ use bevy::{
 };
 use bevy_oddio::{
     builtins::sine::{self, Sine},
-    output::{AudioHandle, AudioSink},
+    output::AudioSink,
     Audio, AudioPlugin,
 };
 use oddio::Sample;
@@ -21,7 +21,7 @@ fn main() {
 #[derive(Deref)]
 struct SineHandle(Handle<Sine>);
 
-struct SineSink(Handle<AudioHandle<Sine>>, Handle<AudioSink<Sine>>);
+struct SineSink(Handle<AudioSink<Sine>>);
 
 fn init_assets(mut commands: Commands, mut assets: ResMut<Assets<Sine>>) {
     let handle = assets.add(Sine);
@@ -34,6 +34,6 @@ fn play_sine(
     noise: Res<SineHandle>,
 ) {
     // Note is in A4.
-    let handles = audio.play(noise.clone(), sine::Settings::new(0.0, 440.0));
-    commands.insert_resource(SineSink(handles.0, handles.1));
+    let handle = audio.play(noise.clone(), sine::Settings::new(0.0, 440.0));
+    commands.insert_resource(SineSink(handle));
 }


### PR DESCRIPTION
# Objective

- Remove `AudioHandle`, as `oddio::Handle::control` can access any filter in the signal.
- Closes #18 

## Solution

- Remove `AudioHandle` in all instances.
- Add `gain` example to demonstrate usage of `Controlled` to control the gain of the sine wave.