### PR TITLE
Correct assertion in `frame_n` usage

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -77,7 +77,7 @@ async fn play<const N: usize, F>(
                 assert_eq!(
                     out_flat.len() % N,
                     0,
-                    "`N` must be a power of 2 that is less than or equal to 64."
+                    "`N` must be a power of 2 that is less than or equal to the output buffer in cpal."
                 );
                 // Safety:
                 // (1) `F` implements `FromFrame<[Sample; N]>`.

--- a/src/output.rs
+++ b/src/output.rs
@@ -63,12 +63,6 @@ async fn play<const N: usize, F>(
 ) where
     F: Frame + FromFrame<[Sample; N]> + 'static,
 {
-    assert_eq!(
-        64 % N,
-        0,
-        "`N` must be a power of 2 that is less than or equal to 64."
-    );
-
     let config = cpal::StreamConfig {
         channels: N.try_into().unwrap_or_else(|err| {
             panic!("Number of channels provided must be reasonable. Error: {err}")
@@ -80,6 +74,11 @@ async fn play<const N: usize, F>(
         .build_output_stream(
             &config,
             move |out_flat: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                assert_eq!(
+                    out_flat.len() % N,
+                    0,
+                    "`N` must be a power of 2 that is less than or equal to 64."
+                );
                 // Safety:
                 // (1) `F` implements `FromFrame<[Sample; N]>`.
                 // (2) 64 is divisible by `N`.

--- a/src/output.rs
+++ b/src/output.rs
@@ -81,7 +81,7 @@ async fn play<const N: usize, F>(
                 );
                 // Safety:
                 // (1) `F` implements `FromFrame<[Sample; N]>`.
-                // (2) 64 is divisible by `N`.
+                // (2) out_flat.len() is divisible by `N`.
                 let out_n = unsafe { frame_n(out_flat) };
                 oddio::run(&mixer, sample_rate.0, out_n);
             },


### PR DESCRIPTION
# Objective

- Usage of `frame_n` isn't exactly correct.
- Closes #15 

## Solution

- Move assertion inside callback
- Changed 64 to `out_flat.len()`
- Update safety comment