### PR TITLE
Add support for spatial audio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ hound = { version = "3.4", optional = true }
 lewton = { version = "0.10", optional = true }
 claxon = { version = "0.4", optional = true }
 minimp3 = { version = "0.5", optional = true }
-# FIXME: remove this on bevy 0.9
-mint = "0.5"
+bevy_math = { version = "0.9", features = ["mint"] }
 
 [features]
 wav = ["hound"]
@@ -30,8 +29,7 @@ ogg = ["lewton"]
 flac = ["claxon"]
 
 [dependencies.bevy]
-# git = "https://github.com/bevyengine/bevy.git"
-version = "0.8"
+version = "0.9"
 default-features = false
 features = ["bevy_asset"]
 
@@ -40,7 +38,7 @@ fastrand = "1.8"
 
 [dev-dependencies.bevy]
 # git = "https://github.com/bevyengine/bevy.git"
-version = "0.8"
+version = "0.9"
 default-features = false
 features = [
   "render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ version = "0.8"
 default-features = false
 features = ["bevy_asset"]
 
+[dependencies.bevy_math]
+version = "0.8"
+features = ["mint"]
+
 [dev-dependencies]
 fastrand = "1.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,6 @@ version = "0.8"
 default-features = false
 features = ["bevy_asset"]
 
-[dependencies.bevy_math]
-version = "0.8"
-features = ["mint"]
-
 [dev-dependencies]
 fastrand = "1.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ hound = { version = "3.4", optional = true }
 lewton = { version = "0.10", optional = true }
 claxon = { version = "0.4", optional = true }
 minimp3 = { version = "0.5", optional = true }
+# FIXME: remove this on bevy 0.9
+mint = "0.5"
 
 [features]
 wav = ["hound"]

--- a/examples/gain.rs
+++ b/examples/gain.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{App, Assets, Commands, Deref, Handle, Res, ResMut, StartupStage},
+    prelude::{App, Assets, Commands, Deref, Handle, Res, ResMut, Resource, StartupStage},
     reflect::TypeUuid,
     time::Time,
     DefaultPlugins,
@@ -31,9 +31,9 @@ fn main() {
         .run();
 }
 
-#[derive(Deref)]
+#[derive(Resource, Deref)]
 struct SineWithGainHandle(Handle<SineWithGain>);
-
+#[derive(Resource)]
 struct SineWithGainSink(Handle<AudioSink<SineWithGain>>);
 
 fn init_assets(mut commands: Commands, mut assets: ResMut<Assets<SineWithGain>>) {
@@ -60,7 +60,7 @@ fn change_volume(
         None => return,
     };
 
-    let factor = (time.seconds_since_startup().sin() + 1.0) / 2.0;
+    let factor = (time.elapsed_seconds_wrapped().sin() + 1.0) / 2.0;
 
     sink.control::<oddio::Gain<_>, _>()
         .set_amplitude_ratio(factor as f32);

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{App, Assets, Commands, Deref, Handle, Res, ResMut, StartupStage},
+    prelude::{App, Assets, Commands, Deref, Handle, Res, ResMut, Resource, StartupStage},
     reflect::TypeUuid,
     DefaultPlugins,
 };
@@ -9,6 +9,7 @@ use oddio::Signal;
 #[derive(TypeUuid)]
 #[uuid = "7cc24057-b499-4f7a-8f8a-e37dfa64be32"]
 struct Noise;
+#[derive(Resource)]
 struct NoiseSignal;
 
 impl Signal for NoiseSignal {
@@ -42,9 +43,9 @@ fn main() {
         .run();
 }
 
-#[derive(Deref)]
+#[derive(Resource, Deref)]
 struct NoiseHandle(Handle<Noise>);
-
+#[derive(Resource)]
 struct NoiseSink(Handle<AudioSink<Noise>>);
 
 fn init_assets(mut commands: Commands, mut assets: ResMut<Assets<Noise>>) {

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    prelude::{App, Assets, Commands, Deref, Handle, Res, ResMut, StartupStage},
+    prelude::{App, Assets, Commands, Deref, Handle, Res, ResMut, Resource, StartupStage},
     DefaultPlugins,
 };
 use bevy_oddio::{
@@ -18,9 +18,9 @@ fn main() {
         .run();
 }
 
-#[derive(Deref)]
+#[derive(Resource, Deref)]
 struct SineHandle(Handle<Sine>);
-
+#[derive(Resource)]
 struct SineSink(Handle<AudioSink<Sine>>);
 
 fn init_assets(mut commands: Commands, mut assets: ResMut<Assets<Sine>>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use bevy::{
     reflect::TypeUuid,
 };
 use frames::{FromFrame, Mono, Stereo};
-use oddio::{Frame, Frames, FramesSignal, Sample, Signal};
+use oddio::{Frame, Frames, FramesSignal, Sample, Signal, SpatialOptions};
 
 pub use oddio;
 use output::{play_queued_audio, AudioOutput, AudioSink, AudioSinks};
@@ -42,6 +42,7 @@ where
     source_handle: BevyHandle<Source>,
     stop_handle: HandleId,
     settings: Source::Settings,
+    spatial_options: Option<SpatialOptions>,
 }
 
 /// Resource that can play any type that implements [`Signal`].
@@ -72,6 +73,7 @@ where
             source_handle,
             stop_handle,
             settings,
+            spatial_options: None,
         };
         self.queue.write().push_back(audio_to_play);
         BevyHandle::<AudioSink<Source>>::weak(stop_handle)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use std::{collections::VecDeque, marker::PhantomData, sync::Arc};
 
 use bevy::{
     asset::{Asset, HandleId},
-    prelude::{AddAsset, App, CoreStage, Handle as BevyHandle, Plugin},
+    prelude::{AddAsset, App, CoreStage, Handle as BevyHandle, Plugin, Resource},
     reflect::TypeUuid,
 };
 use frames::{FromFrame, Mono, Stereo};
@@ -64,6 +64,7 @@ struct BufferedSettings {
 }
 
 /// Resource that can play any type that implements [`Signal`].
+#[derive(Resource)]
 pub struct Audio<F, Source = AudioSource<F>>
 where
     Source: ToSignal + Asset,

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,7 +2,7 @@ use std::mem::ManuallyDrop;
 
 use bevy::{
     asset::{Asset, Handle as BevyHandle, HandleId},
-    prelude::{Assets, Deref, DerefMut, Res, ResMut},
+    prelude::{Assets, Deref, DerefMut, Res, ResMut, Resource},
     reflect::TypeUuid,
     tasks::AsyncComputeTaskPool,
     utils::HashMap,
@@ -22,6 +22,7 @@ use crate::{
 pub mod spatial;
 
 /// Used internally in handling audio output.
+#[derive(Resource)]
 pub struct AudioOutput<const N: usize, F: Frame + FromFrame<[Sample; N]>> {
     mixer_handle: OddioHandle<Mixer<F>>,
 }
@@ -118,7 +119,7 @@ pub fn play_queued_audio<const N: usize, F, Source>(
             let sink = audio_output.play::<Source>(audio_source.to_signal(config.settings));
             // Unlike bevy_audio, we should not drop this
             let sink_handle = sink_assets.set(config.stop_handle, sink);
-            sinks.insert(sink_handle.id, sink_handle.clone());
+            sinks.insert(sink_handle.id(), sink_handle.clone());
         } else {
             queue.push_back(config);
         }
@@ -134,7 +135,7 @@ pub struct AudioSink<Source: ToSignal + Asset>(
 );
 
 /// Storage of all audio sinks.
-#[derive(Deref, DerefMut)]
+#[derive(Resource, Deref, DerefMut)]
 pub struct AudioSinks<Source: ToSignal + Asset>(HashMap<HandleId, BevyHandle<AudioSink<Source>>>);
 
 impl<Source: ToSignal + Asset> Default for AudioSinks<Source> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -112,7 +112,7 @@ pub fn play_queued_audio<const N: usize, F, Source>(
     while i < len {
         let config = queue.pop_front().unwrap(); // This should not panic
         if let Some(audio_source) = sources.get(&config.source_handle) {
-            if config.spatial_options.is_some() {
+            if config.spatial_settings.is_some() {
                 return;
             }
             let sink = audio_output.play::<Source>(audio_source.to_signal(config.settings));

--- a/src/output/spatial.rs
+++ b/src/output/spatial.rs
@@ -1,0 +1,158 @@
+use std::mem::ManuallyDrop;
+
+use bevy::{
+    asset::{Asset, Handle as BevyHandle, HandleId},
+    prelude::{Assets, Deref, DerefMut, Res, ResMut},
+    reflect::TypeUuid,
+    tasks::AsyncComputeTaskPool,
+    utils::HashMap,
+};
+use cpal::{
+    traits::{DeviceTrait, StreamTrait},
+    Device, SampleRate,
+};
+use oddio::{
+    Frame, Handle as OddioHandle, Sample, Seek, Signal, Spatial, SpatialOptions, SpatialScene,
+    SplitSignal, Stop,
+};
+
+use crate::{Audio, AudioToPlay, ToSignal};
+
+use super::get_host_info;
+
+/// Used internally in handling spatial audio output.
+pub struct SpatialAudioOutput {
+    spatial_scene_handle: OddioHandle<SpatialScene>,
+}
+
+impl SpatialAudioOutput {
+    fn play<S>(&mut self, signal: S::Signal, options: SpatialOptions) -> SpatialAudioSink<S>
+    where
+        S: ToSignal + Asset,
+        S::Signal: Seek + Signal<Frame = Sample> + Send,
+    {
+        SpatialAudioSink(ManuallyDrop::new(
+            self.spatial_scene_handle.control().play(signal, options),
+        ))
+    }
+}
+
+impl Default for SpatialAudioOutput {
+    fn default() -> Self {
+        let task_pool = AsyncComputeTaskPool::get();
+        let (spatial_scene_handle, spatial_scene) = oddio::split(SpatialScene::new());
+
+        let (device, sample_rate) = get_host_info();
+
+        task_pool
+            .spawn(async move { play(spatial_scene, &device, sample_rate) })
+            .detach();
+
+        Self {
+            spatial_scene_handle,
+        }
+    }
+}
+
+fn play(spatial_scene: SplitSignal<SpatialScene>, device: &Device, sample_rate: SampleRate) {
+    let config = cpal::StreamConfig {
+        channels: 1,
+        sample_rate,
+        buffer_size: cpal::BufferSize::Default,
+    };
+
+    let stream = device
+        .build_output_stream(
+            &config,
+            move |out: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                let out_stereo = oddio::frame_stereo(out);
+                oddio::run(&spatial_scene, sample_rate.0, out_stereo);
+            },
+            move |err| bevy::utils::tracing::error!("Error in cpal: {err:?}"),
+        )
+        .expect("Cannot build output stream.");
+    stream.play().expect("Cannot play stream.");
+
+    // Do not drop the stream! or else there will be no audio
+    std::thread::sleep(std::time::Duration::MAX);
+}
+
+/// System to play queued spatial audio in [`Audio`].
+pub fn play_queued_spatial_audio<const N: usize, F, Source>(
+    mut audio_output: ResMut<SpatialAudioOutput>,
+    audio: Res<Audio<Sample, Source>>,
+    sources: Res<Assets<Source>>,
+    mut sink_assets: ResMut<Assets<SpatialAudioSink<Source>>>,
+    mut sinks: ResMut<SpatialAudioSinks<Source>>,
+) where
+    Source: ToSignal + Asset + Send,
+    Source::Signal: Seek + Signal<Frame = Sample> + Send,
+{
+    let mut queue = audio.queue.write();
+    let len = queue.len();
+    let mut i = 0;
+    while i < len {
+        let config = queue.pop_front().unwrap(); // This should not panic
+        if let Some(audio_source) = sources.get(&config.source_handle) {
+            if let Some(spatial_options) = config.spatial_options {
+                let sink = audio_output
+                    .play::<Source>(audio_source.to_signal(config.settings), spatial_options);
+                // Unlike bevy_audio, we should not drop this
+                let sink_handle = sink_assets.set(config.stop_handle, sink);
+                sinks.insert(sink_handle.id, sink_handle.clone());
+            }
+        } else {
+            queue.push_back(config);
+        }
+        i += 1;
+    }
+}
+
+/// Asset that controls the playback of the spatial sound.
+#[derive(TypeUuid, Deref, DerefMut)]
+#[uuid = "4b135d1c-68cb-4104-b5c5-4be8bea6c46c"]
+pub struct SpatialAudioSink<Source: ToSignal + Asset>(
+    ManuallyDrop<OddioHandle<Spatial<Stop<<Source as ToSignal>::Signal>>>>,
+);
+
+/// Storage of all spatial audio sinks.
+#[derive(Deref, DerefMut)]
+pub struct SpatialAudioSinks<Source: ToSignal + Asset>(
+    HashMap<HandleId, BevyHandle<SpatialAudioSink<Source>>>,
+);
+
+impl<Source: ToSignal + Asset> Default for SpatialAudioSinks<Source> {
+    fn default() -> Self {
+        Self(HashMap::default())
+    }
+}
+
+impl<F, Source> Audio<F, Source>
+where
+    Source: ToSignal + Asset,
+    Source::Signal: Seek + Signal<Frame = f32>,
+    F: Frame,
+{
+    /// Play the given type that implements [`Signal`].
+    ///
+    /// The signal must implement [`oddio::Seek`]
+    /// and its frame must be [`f32`].
+    ///
+    /// Returns a handle that can be paused or permanently stopped.
+    pub fn play_spatial(
+        &mut self,
+        source_handle: BevyHandle<Source>,
+        settings: Source::Settings,
+        spatial_options: SpatialOptions,
+    ) -> BevyHandle<SpatialAudioSink<Source>> {
+        let stop_handle = HandleId::random::<SpatialAudioSink<Source>>();
+        let audio_to_play = AudioToPlay {
+            source_handle,
+            stop_handle,
+            settings,
+            spatial_options: Some(spatial_options),
+        };
+        self.queue.write().push_back(audio_to_play);
+        BevyHandle::<SpatialAudioSink<Source>>::weak(stop_handle)
+    }
+}

--- a/src/output/spatial.rs
+++ b/src/output/spatial.rs
@@ -31,6 +31,8 @@ impl SpatialAudioOutput {
     /// Rotate the listener.
     ///
     /// See [`SpatialSceneControl::set_listener_rotation`] for more information.
+    ///
+    /// [`SpatialSceneControl::set_listener_rotation`]: oddio::SpatialSceneControl::set_listener_rotation
     pub fn set_listener_rotation(&mut self, rotation: Quaternion<f32>) {
         self.spatial_scene_handle
             .control()
@@ -162,7 +164,7 @@ pub fn play_queued_spatial_buffered_audio<Source>(
     mut sinks: ResMut<SpatialBufferedAudioSinks<Source>>,
 ) where
     Source: ToSignal + Asset + Send,
-    Source::Signal: Seek + Signal<Frame = Sample> + Send,
+    Source::Signal: Signal<Frame = Sample> + Send,
 {
     let mut queue = audio.queue.write();
     let len = queue.len();


### PR DESCRIPTION
# Objective

- Add basic support for spatial audio
- Update to 0.9
- Unblocks #22

## Solution

- Added `play_spatial`, `play_spatial_buffered` and `set_listener_rotation`.

## WARNING

The two examples are very flaky on my end!! Can someone test this?

Basically when running the examples, it sometimes work, but sometimes it does not move at all. It's pretty weird. To reproduce: simply run the example again and again.