### PR TITLE
Split Audio impl to relax trait bounds for spatial_buffered

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ use bevy_oddio::frames::Stereo;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugin(AudioPlugin::new())
         .add_startup_system(play_background_audio)
         .run();
 }

--- a/examples/gain.rs
+++ b/examples/gain.rs
@@ -23,7 +23,7 @@ impl ToSignal for SineWithGain {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugin(AudioPlugin::new())
         .add_audio_source::<1, _, SineWithGain>()
         .add_startup_system(init_assets)
         .add_startup_system_to_stage(StartupStage::PostStartup, play_sine_with_gain)

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -36,7 +36,7 @@ impl ToSignal for Noise {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugin(AudioPlugin::new())
         .add_audio_source::<2, _, Noise>()
         .add_startup_system(init_assets)
         .add_startup_system_to_stage(StartupStage::PostStartup, play_noise)

--- a/examples/sine.rs
+++ b/examples/sine.rs
@@ -12,7 +12,7 @@ use oddio::Sample;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugin(AudioPlugin::new())
         .add_startup_system(init_assets)
         .add_startup_system_to_stage(StartupStage::PostStartup, play_sine)
         .run();

--- a/examples/spatial_2d.rs
+++ b/examples/spatial_2d.rs
@@ -18,7 +18,7 @@ use oddio::{Sample, Spatial, SpatialOptions};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugin(AudioPlugin::new())
         .add_startup_system(init_assets)
         .add_startup_system_to_stage(StartupStage::PostStartup, setup)
         .add_system(change_velocity)

--- a/examples/spatial_3d.rs
+++ b/examples/spatial_3d.rs
@@ -17,7 +17,7 @@ use oddio::{Sample, Spatial, SpatialOptions};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugin(AudioPlugin::new())
         .add_startup_system(init_assets)
         .add_startup_system_to_stage(StartupStage::PostStartup, setup)
         .add_system(change_velocity)

--- a/examples/stop.rs
+++ b/examples/stop.rs
@@ -14,7 +14,7 @@ use oddio::Sample;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AudioPlugin)
+        .add_plugin(AudioPlugin::new())
         .add_startup_system(init_assets)
         .add_startup_system_to_stage(StartupStage::PostStartup, play_sine)
         .add_system(get_input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ use output::{
 };
 use parking_lot::RwLock;
 
+pub use cpal;
+
 /// [`oddio`] builtin types that can be directly used in [`Audio::play`].
 pub mod builtins;
 /// Newtypes for working around [bevyengine/bevy#5432](https://github.com/bevyengine/bevy/issues/5432)

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,4 @@
-use std::mem::ManuallyDrop;
+use std::{mem::ManuallyDrop, sync::Mutex};
 
 use bevy::{
     asset::{Asset, Handle as BevyHandle, HandleId},
@@ -89,9 +89,8 @@ fn play<const N: usize, F>(
         )
         .expect("Cannot build output stream.");
     stream.play().expect("Cannot play stream.");
-
     // Do not drop the stream! or else there will be no audio
-    std::thread::sleep(std::time::Duration::MAX);
+    std::mem::forget(stream);
 }
 
 /// System to play queued audio in [`Audio`].

--- a/src/output.rs
+++ b/src/output.rs
@@ -144,11 +144,19 @@ impl<Source: ToSignal + Asset> Default for AudioSinks<Source> {
     }
 }
 
+/// Set this static before adding the bevy_oddio plugin to override cpal audio
+/// settings.
+pub static STREAM_CONFIG_RANGE_OVERRIDE: Mutex<Option<SupportedStreamConfigRange>> =
+    Mutex::new(None);
+
 fn get_host_info() -> (Device, SupportedStreamConfigRange) {
     let host = cpal::default_host();
     let device = host
         .default_output_device()
         .expect("No default output device available.");
+    if let Some(config_range) = STREAM_CONFIG_RANGE_OVERRIDE.lock().unwrap().as_ref() {
+        return (device, config_range.clone());
+    }
     let supported_config_range = device
         .supported_output_configs()
         .into_iter()

--- a/src/output/spatial.rs
+++ b/src/output/spatial.rs
@@ -288,8 +288,8 @@ where
         max_distance: f32,
         rate: u32,
         buffer_duration: f32,
-    ) -> BevyHandle<SpatialAudioSink<Source>> {
-        let stop_handle = HandleId::random::<SpatialAudioSink<Source>>();
+    ) -> BevyHandle<SpatialBufferedAudioSink<Source>> {
+        let stop_handle = HandleId::random::<SpatialBufferedAudioSink<Source>>();
         let audio_to_play = AudioToPlay {
             source_handle,
             stop_handle,
@@ -304,6 +304,6 @@ where
             }),
         };
         self.queue.write().push_back(audio_to_play);
-        BevyHandle::<SpatialAudioSink<Source>>::weak(stop_handle)
+        BevyHandle::<SpatialBufferedAudioSink<Source>>::weak(stop_handle)
     }
 }

--- a/src/output/spatial.rs
+++ b/src/output/spatial.rs
@@ -117,7 +117,7 @@ fn play(
     stream.play().expect("Cannot play stream.");
 
     // Do not drop the stream! or else there will be no audio
-    std::thread::sleep(std::time::Duration::MAX);
+    std::mem::forget(stream);
 }
 
 /// System to play queued spatial audio in [`Audio`].

--- a/src/output/spatial.rs
+++ b/src/output/spatial.rs
@@ -267,7 +267,14 @@ where
         self.queue.write().push_back(audio_to_play);
         BevyHandle::<SpatialAudioSink<Source>>::weak(stop_handle)
     }
+}
 
+impl<F, Source> Audio<F, Source>
+where
+    Source: ToSignal + Asset,
+    Source::Signal: Signal<Frame = f32>,
+    F: Frame,
+{
     /// Play the given type that implements [`Signal`].
     ///
     /// The signal's frame must be [`f32`].


### PR DESCRIPTION
# Objective

- Fix spatial audio playback.

## Solution

- `std::mem:forget(stream)` instead of blocking bevy threads.
- Add necessary initialization resources for spatial audio.

---

## Changelog

- Relaxed trait bounds for `play_spatial_buffered` to not require `Seek`.
- Exposed `static` for configuring cpal settings.
